### PR TITLE
Adding proxy config while making http call

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -70,6 +70,7 @@ func CreateHttpClient(disableSecurityCheck bool) *http.Client {
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: constants.MaxIdleConnections,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: disableSecurityCheck},
+			Proxy:           http.ProxyFromEnvironment,
 		},
 		Timeout: time.Duration(constants.RequestTimeout) * time.Second,
 	}


### PR DESCRIPTION
Earlier, the client call was not picking up the proxy config of the system where the plugin is running.
This will cause failures if the client requires a proxy config while making connections/cf calls.

Fixing this by adding the requisite config.