### PR TITLE
Introducing the restore-status command for cf cli

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -5,10 +5,12 @@ import (
 )
 
 const (
-	Red                color.Attribute = color.FgRed
-        Green              color.Attribute = color.FgGreen
-        Cyan               color.Attribute = color.FgCyan
-        White              color.Attribute = color.FgWhite
-        MaxIdleConnections int             = 25
-        RequestTimeout     int             = 180
+	Red                        color.Attribute = color.FgRed
+	Green                      color.Attribute = color.FgGreen
+	Cyan                       color.Attribute = color.FgCyan
+	White                      color.Attribute = color.FgWhite
+	MaxIdleConnections         int             = 25
+	RequestTimeout             int             = 180
+	OKHttpStatusResponse       string          = "200 OK"
+	AcceptedHttpStatusResponse string          = "202 Accepted"
 )

--- a/guidTranslator/guidTranslator.go
+++ b/guidTranslator/guidTranslator.go
@@ -354,7 +354,7 @@ func FindDeletedInstanceGuid(cliConnection plugin.CliConnection, instanceName st
 				if strings.Contains(instanceNameTemp, userInput) {
 					flag = 1
 					guidInstanceMap[guidTemp] = instanceNameTemp
-					instanceNameTemp =""
+					instanceNameTemp = ""
 				}
 			}
 		}
@@ -383,7 +383,6 @@ func FindInstanceGuid(cliConnection plugin.CliConnection, instanceName string, o
 	var guid string
 	var nextPage bool = false
 
-	
 	var userInput string = "\"" + instanceName + "\""
 
 	for cmd != "null" {
@@ -435,6 +434,8 @@ func FindInstanceGuid(cliConnection plugin.CliConnection, instanceName string, o
 						if strings.Contains(spaceGuid, userSpaceGuid) {
 							guid = guidTemp
 							spaceGuid = userSpaceGuid
+							guid = strings.TrimRight(guid, ",")
+							guid = strings.Trim(guid, "\"")
 							return guid
 						}
 

--- a/guidTranslator/guidTranslator_test.go
+++ b/guidTranslator/guidTranslator_test.go
@@ -3,9 +3,9 @@ package guidTranslator
 import (
 	"bufio"
 	"fmt"
-	"os"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"os"
 	"testing"
 )
 
@@ -113,7 +113,7 @@ var _ = Describe("guidTranslator", func() {
 				}
 
 				result := FindInstanceGuid(nil, instanceName, output, userSpaceGuid)
-				Expect(result).To(Equal("\"8912303d-3cdf-476e-b864-47f008b5ba5e\","))
+				Expect(result).To(Equal("8912303d-3cdf-476e-b864-47f008b5ba5e"))
 			})
 		})
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -173,7 +173,7 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 		} else {
 			fmt.Println("Restore has been initiated for the instance name:", AddColor(serviceInstanceName, cyan), " using time stamp:", AddColor(timeStamp, cyan))
 		}
-		fmt.Println("Please check the status of restore by entering 'cf show-restore-status SERVICE_INSTANCE_NAME'")
+		fmt.Println("Please check the status of restore by entering 'cf restore SERVICE_INSTANCE_NAME'")
 	}
 
 	errors.ErrorIsNil(err)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -160,7 +160,7 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 		}
 	}
 
-	if respOperation, flag := respObject["name"].(string); flag != false {
+	if resp.Status == "202 Accepted" {
 		fmt.Println(AddColor("OK", green))
 		fmt.Println("Operation: ", respOperation)
 		if restoreGuid, flag := respObject["guid"].(string); flag != false {
@@ -335,12 +335,12 @@ func (c *RestoreCommand) AbortRestore(cliConnection plugin.CliConnection, servic
 		}
 	}
 
-	if respStatus == 202 {
+	if resp.Status == "202 Accepted" {
 		fmt.Println(AddColor("OK", green))
 		fmt.Println("Restore has been aborted for the instance name:", color.CyanString(serviceInstanceName))
 	}
 
-	if respStatus == 200 {
+	if resp.Status == "200 OK" {
 		fmt.Println("currently no restore in progress for this service instance")
 	}
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -128,8 +128,6 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 	}
 	fmt.Println(req_body)
 	var guid string = guidTranslator.FindInstanceGuid(cliConnection, serviceInstanceName, nil, "")
-	guid = strings.TrimRight(guid, ",")
-	guid = strings.Trim(guid, "\"")
 
 	var apiEndpoint string = helper.GetApiEndpoint(helper.ReadConfigJsonFile())
 	var broker string = GetBrokerName()
@@ -191,8 +189,6 @@ func (c *RestoreCommand) RestoreInfo(cliConnection plugin.CliConnection, service
 	client := GetHttpClient()
 
 	var guid string = guidTranslator.FindInstanceGuid(cliConnection, serviceInstanceName, nil, "")
-	guid = strings.TrimRight(guid, ",")
-	guid = strings.Trim(guid, "\"")
 
 	var userSpaceGuid string = helper.GetSpaceGUID(helper.ReadConfigJsonFile())
 
@@ -302,8 +298,6 @@ func (c *RestoreCommand) AbortRestore(cliConnection plugin.CliConnection, servic
 	client := GetHttpClient()
 
 	var guid string = guidTranslator.FindInstanceGuid(cliConnection, serviceInstanceName, nil, "")
-	guid = strings.TrimRight(guid, ",")
-	guid = strings.Trim(guid, "\"")
 
 	var userSpaceGuid string = helper.GetSpaceGUID(helper.ReadConfigJsonFile())
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -161,6 +161,32 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 
 }
 
+func (c *RestoreCommand) RestoreInfo(cliConnection plugin.CliConnection, serviceInstanceName string) {
+	fmt.Println("Showing the status of the last restore operation for", AddColor(serviceInstanceName, cyan) ," ...")
+
+	if helper.GetAccessToken(helper.ReadConfigJsonFile()) == "" {
+                errors.NoAccessTokenError("Access Token")
+        }
+
+        client := GetHttpClient()
+
+        var guid string = guidTranslator.FindInstanceGuid(cliConnection, serviceInstanceName, nil, "")
+        guid = strings.TrimRight(guid, ",")
+        guid = strings.Trim(guid, "\"")
+
+        var userSpaceGuid string = helper.GetSpaceGUID(helper.ReadConfigJsonFile())
+
+        var apiEndpoint string = helper.GetApiEndpoint(helper.ReadConfigJsonFile())
+        var broker string = GetBrokerName()
+        var extUrl string = GetExtUrl()
+
+        apiEndpoint = strings.Replace(apiEndpoint, "api", broker, 1)
+
+	var url string = apiEndpoint + extUrl + "/service_instances/" + guid + "/restore?space_guid=" + userSpaceGuid
+
+ 	req, err := http.NewRequest("GET", url, nil)
+}
+
 func (c *RestoreCommand) AbortRestore(cliConnection plugin.CliConnection, serviceInstanceName string) {
 	fmt.Println("Aborting restore for ", AddColor(serviceInstanceName, cyan), "...")
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/SAP/service-fabrik-cli-plugin/constants"
 	"github.com/SAP/service-fabrik-cli-plugin/errors"
 	"github.com/SAP/service-fabrik-cli-plugin/guidTranslator"
 	"github.com/SAP/service-fabrik-cli-plugin/helper"
@@ -160,7 +161,7 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 		}
 	}
 
-	if resp.Status == "202 Accepted" {
+	if resp.Status == constants.AcceptedHttpStatusResponse {
 		fmt.Println(AddColor("OK", green))
 		if respOperation, flag := respObject["name"].(string); flag != false {
 			fmt.Println("Operation: ", respOperation)
@@ -228,7 +229,7 @@ func (c *RestoreCommand) RestoreInfo(cliConnection plugin.CliConnection, service
 		}
 	}
 
-	if resp.Status == "200 OK" {
+	if resp.Status == constants.OKHttpStatusResponse {
 		fmt.Println(AddColor("OK", green))
 
 		table := tablewriter.NewWriter(os.Stdout)
@@ -338,12 +339,12 @@ func (c *RestoreCommand) AbortRestore(cliConnection plugin.CliConnection, servic
 		}
 	}
 
-	if resp.Status == "202 Accepted" {
+	if resp.Status == constants.AcceptedHttpStatusResponse {
 		fmt.Println(AddColor("OK", green))
 		fmt.Println("Restore has been aborted for the instance name:", color.CyanString(serviceInstanceName))
 	}
 
-	if resp.Status == "200 OK" {
+	if resp.Status == constants.OKHttpStatusResponse {
 		fmt.Println("currently no restore in progress for this service instance")
 	}
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -162,7 +162,9 @@ func (c *RestoreCommand) StartRestore(cliConnection plugin.CliConnection, servic
 
 	if resp.Status == "202 Accepted" {
 		fmt.Println(AddColor("OK", green))
-		fmt.Println("Operation: ", respOperation)
+		if respOperation, flag := respObject["name"].(string); flag != false {
+			fmt.Println("Operation: ", respOperation)
+		}
 		if restoreGuid, flag := respObject["guid"].(string); flag != false {
 			fmt.Println("Restore Guid: ", restoreGuid)
 		}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -325,15 +325,16 @@ func (c *RestoreCommand) AbortRestore(cliConnection plugin.CliConnection, servic
 		fmt.Println(err)
 	}
 
-	respStatus := respObject["status"].(float64)
+	if respStatus, flag := respObject["status"].(float64); flag != false {
 
-	if (respStatus != 202) && (respStatus != 200) {
-		fmt.Println(AddColor("FAILED", red))
-		if respError, flag := respObject["error"].(string); flag != false {
-			fmt.Println("Error: ", respError)
-		}
-		if respMessage, flag := respObject["description"].(string); flag != false {
-			fmt.Println("Message: ", respMessage)
+		if (respStatus != 202) && (respStatus != 200) {
+			fmt.Println(AddColor("FAILED", red))
+			if respError, flag := respObject["error"].(string); flag != false {
+				fmt.Println("Error: ", respError)
+			}
+			if respMessage, flag := respObject["description"].(string); flag != false {
+				fmt.Println("Message: ", respMessage)
+			}
 		}
 	}
 

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -68,6 +68,14 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 		backup.NewBackupCommand(cliConnection).BackupInfo(cliConnection, args[1])
 	}
 
+	if args[0] == "restore" { //If user enters, "cf restore SERVICE_INSTANCE_NAME"
+		if argLength != 2 {
+			errors.IncorrectNumberOfArguments()
+			return
+		}
+		restore.NewRestoreCommand(cliConnection).RestoreInfo(cliConnection, args[1])
+	}
+
 	var cmds []string = strings.Split(args[0], "-")
 	//3 overall switches: backup, restore & events
 	if len(cmds) >= 2 {
@@ -182,14 +190,6 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 				} else {
 					os.Exit(7)
 				}
-			case "show":
-				if argLength != 2 {
-					errors.IncorrectNumberOfArguments()
-				}
-				if cmds[2] != "status" {
-					errors.InvalidArgument()
-				}
-				restore.NewRestoreCommand(cliConnection).RestoreInfo(cliConnection, args[1])
 			}
 		case "events":
 			switch cmds[0] {
@@ -285,10 +285,10 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 				},
 			},
 			{
-				Name:     "show-restore-status",
+				Name:     "restore",
 				HelpText: "Status of the last Restore operation of a service-instance",
 				UsageDetails: plugin.Usage{
-					Usage: "cf show-restore-status SERVICE_INSTANCE_NAME",
+					Usage: "cf restore SERVICE_INSTANCE_NAME",
 				},
 			},
 			{

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -282,11 +282,11 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 				},
 			},
 			{
-				Name: "show-restore",
+				Name:     "show-restore",
 				HelpText: "Status of the last Restore operation of a service-instance",
 				UsageDetails: plugin.Usage{
-                                        Usage: "cf show-restore SERVICE_INSTANCE_NAME",
-                                },
+					Usage: "cf show-restore SERVICE_INSTANCE_NAME",
+				},
 			},
 			{
 				Name:     "abort-restore",

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -70,7 +70,7 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 
 	var cmds []string = strings.Split(args[0], "-")
 	//3 overall switches: backup, restore & events
-	if len(cmds) == 2 {
+	if len(cmds) > 2 {
 
 		switch cmds[1] {
 		case "backup":
@@ -186,6 +186,9 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 				if argLength != 2 {
 					errors.IncorrectNumberOfArguments()
 				}
+				if cmds[2] != "status" {
+					errors.InvalidArgument()
+				}
 				restore.NewRestoreCommand(cliConnection).RestoreInfo(cliConnection, args[1])
 			}
 		case "events":
@@ -282,10 +285,10 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 				},
 			},
 			{
-				Name:     "show-restore",
+				Name:     "show-restore-status",
 				HelpText: "Status of the last Restore operation of a service-instance",
 				UsageDetails: plugin.Usage{
-					Usage: "cf show-restore SERVICE_INSTANCE_NAME",
+					Usage: "cf show-restore-status SERVICE_INSTANCE_NAME",
 				},
 			},
 			{

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -182,6 +182,11 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 				} else {
 					os.Exit(7)
 				}
+			case "show":
+				if argLength != 2 {
+					errors.IncorrectNumberOfArguments()
+				}
+				restore.NewRestoreCommand(cliConnection).RestoreInfo(cliConnection, args[1])
 			}
 		case "events":
 			switch cmds[0] {
@@ -275,6 +280,13 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 				UsageDetails: plugin.Usage{
 					Usage: "cf start-restore SERVICE_INSTANCE_NAME --backup_guid BACKUP_ID \n     cf start-restore SERVICE_INSTANCE_NAME --timestamp TIME_STAMP",
 				},
+			},
+			{
+				Name: "show-restore",
+				HelpText: "Status of the last Restore operation of a service-instance",
+				UsageDetails: plugin.Usage{
+                                        Usage: "cf show-restore SERVICE_INSTANCE_NAME",
+                                },
 			},
 			{
 				Name:     "abort-restore",

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -70,7 +70,7 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) Run(cliConnection plugin.CliConn
 
 	var cmds []string = strings.Split(args[0], "-")
 	//3 overall switches: backup, restore & events
-	if len(cmds) > 2 {
+	if len(cmds) >= 2 {
 
 		switch cmds[1] {
 		case "backup":


### PR DESCRIPTION
This introduces a command for CF CLI plugin for checking the status of the last restore triggered on an instance.
Earlier, the user could perform a `cf service SERVICE_INSTANCE_NAME` and see the status of restore in `update in progress` or `update succeeded`. But, with the recent changes in the restore flow, it necessitated a new command to be introduced for this purpose.

The command newly introduced has usage like:
`cf restore SERVICE_INSTANCE_NAME` and returns a restore-status quite similar to the backup-status already displayed by the plugin.

Additional changes introduced in this PR are:
Moving to json-parsing instead of text/string parsing in the restore commands. This was earlier implemented for backup commands. There is no change in functionality as such. Just a better way of handling the API endpoints in the code.