### PR TITLE
removing unsupported commands and adding few validations in commands

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -290,13 +290,18 @@ func (c *BackupCommand) ListBackupsByInstance(cliConnection plugin.CliConnection
 		fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance", AddColor(serviceInstanceName, constants.Cyan), "...")
 	} else {
 		guid = instanceGuid
+		serviceInstanceName = guidTranslator.FindInstanceName(cliConnection, guid, nil)
+		serviceInstanceName = strings.Trim(serviceInstanceName, ",")
+		serviceInstanceName = strings.Trim(serviceInstanceName, "\"")
 		fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance GUID", AddColor(instanceGuid, constants.Cyan), "...")
 	}
 
-	var serviceName string
-	serviceName = guidTranslator.ServiceNameFromInstance(cliConnection, guid)
-	if !guidTranslator.IsServiceNameValid(serviceName) {
-		errors.IncorrectServiceType(serviceInstanceName, serviceName)
+	if serviceInstanceName != "" {
+		serviceName := guidTranslator.ServiceNameFromInstance(cliConnection, serviceInstanceName)
+		fmt.Println("Instance ", AddColor(serviceInstanceName, constants.Cyan), "is of service ", AddColor(serviceName, constants.Cyan))
+		if !guidTranslator.IsServiceNameValid(serviceName) {
+			errors.IncorrectServiceType(serviceInstanceName, serviceName)
+		}
 	}
 	var apiEndpoint string = helper.GetApiEndpoint(helper.ReadConfigJsonFile())
 	var broker string = GetBrokerName()

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -5,18 +5,19 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/SAP/service-fabrik-cli-plugin/errors"
-	"github.com/SAP/service-fabrik-cli-plugin/guidTranslator"
-	"github.com/SAP/service-fabrik-cli-plugin/helper"
-	"github.com/SAP/service-fabrik-cli-plugin/constants"
-	"github.com/cloudfoundry/cli/plugin"
-	"github.com/fatih/color"
-	"github.com/olekukonko/tablewriter"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/SAP/service-fabrik-cli-plugin/constants"
+	"github.com/SAP/service-fabrik-cli-plugin/errors"
+	"github.com/SAP/service-fabrik-cli-plugin/guidTranslator"
+	"github.com/SAP/service-fabrik-cli-plugin/helper"
+	"github.com/cloudfoundry/cli/plugin"
+	"github.com/fatih/color"
+	"github.com/olekukonko/tablewriter"
 )
 
 type BackupCommand struct {
@@ -28,7 +29,6 @@ func NewBackupCommand(cliConnection plugin.CliConnection) *BackupCommand {
 	command.cliConnection = cliConnection
 	return command
 }
-
 
 func AddColor(text string, textColor color.Attribute) string {
 	printer := color.New(textColor).Add(color.Bold).SprintFunc()
@@ -183,7 +183,6 @@ func (c *BackupCommand) BackupInfo(cliConnection plugin.CliConnection, backupId 
 
 }
 
-
 func (c *BackupCommand) ListBackupsByDeletedInstanceName(cliConnection plugin.CliConnection, serviceInstanceName string) {
 	fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance", AddColor(serviceInstanceName, constants.Cyan), "...")
 
@@ -288,10 +287,16 @@ func (c *BackupCommand) ListBackupsByInstance(cliConnection plugin.CliConnection
 		guid = guidTranslator.FindInstanceGuid(cliConnection, serviceInstanceName, nil, "")
 		guid = strings.Trim(guid, ",")
 		guid = strings.Trim(guid, "\"")
-	 fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance", AddColor(serviceInstanceName, constants.Cyan), "...")
+		fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance", AddColor(serviceInstanceName, constants.Cyan), "...")
 	} else {
 		guid = instanceGuid
-	fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance GUID", AddColor(instanceGuid, constants.Cyan), "...")
+		fmt.Println("Getting the list of  backups in the org", AddColor(helper.GetOrgName(helper.ReadConfigJsonFile()), constants.Cyan), "/ space", AddColor(helper.GetSpaceName(helper.ReadConfigJsonFile()), constants.Cyan), "/ service instance GUID", AddColor(instanceGuid, constants.Cyan), "...")
+	}
+
+	var serviceName string
+	serviceName = guidTranslator.ServiceNameFromInstance(cliConnection, guid)
+	if !guidTranslator.IsServiceNameValid(serviceName) {
+		errors.IncorrectServiceType(serviceInstanceName, serviceName)
 	}
 	var apiEndpoint string = helper.GetApiEndpoint(helper.ReadConfigJsonFile())
 	var broker string = GetBrokerName()

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -14,3 +14,5 @@ const (
 	OKHttpStatusResponse       string          = "200 OK"
 	AcceptedHttpStatusResponse string          = "202 Accepted"
 )
+
+var ValidServices = []string{"blueprint", "postgresql", "mongodb", "redis"}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,10 +2,11 @@ package errors
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/cli/cf/errors"
-	"github.com/fatih/color"
 	"log"
 	"os"
+
+	"github.com/cloudfoundry/cli/cf/errors"
+	"github.com/fatih/color"
 )
 
 func Condition(cond bool, message string) {
@@ -52,6 +53,13 @@ func IncorrectSpace(orgName string, spaceName string) {
 func IncorrectInstanceName(instanceName string) {
 	color.Red("FAILED")
 	fmt.Println("Service Instance \"" + instanceName + "\" doesn't exist.")
+	os.Exit(3)
+}
+
+func IncorrectServiceType(instanceName string, serviceName string) {
+	color.Red("FAILED")
+	fmt.Println("Service Instance \"" + instanceName + "\" is of service \"" + serviceName + "\".")
+	fmt.Println("Service \"" + serviceName + "\" is not supported for this command.")
 	os.Exit(3)
 }
 

--- a/guidTranslator/guidTranslator.go
+++ b/guidTranslator/guidTranslator.go
@@ -1,10 +1,12 @@
 package guidTranslator
 
 import (
+	"strings"
+
 	"code.cloudfoundry.org/cli/plugin"
+	"github.com/SAP/service-fabrik-cli-plugin/constants"
 	"github.com/SAP/service-fabrik-cli-plugin/errors"
 	"github.com/SAP/service-fabrik-cli-plugin/helper"
-	"strings"
 )
 
 type CliCmd struct{}
@@ -69,6 +71,23 @@ func FindInstanceName(cliConnection plugin.CliConnection, InstanceGuid string, o
 	return "" //if no match is found, return "Invalid name"
 }
 
+func ServiceNameFromInstance(cliConnection plugin.CliConnection, instanceId string) string {
+	serviceInstance, err := cliConnection.GetService(instanceId)
+	if err != nil {
+		errors.CfCliPluginError("/v2/service_instance/" + instanceId)
+	}
+	serviceName := serviceInstance.ServiceOffering.Name
+	return serviceName
+}
+
+func IsServiceNameValid(serviceName string) bool {
+	for _, service := range constants.ValidServices {
+		if serviceName == service {
+			return true
+		}
+	}
+	return false
+}
 func FindServiceName(cliConnection plugin.CliConnection, serviceId string, output []string) string {
 	var cmd string
 	var serviceIdTemp string

--- a/guidTranslator/guidTranslator.go
+++ b/guidTranslator/guidTranslator.go
@@ -1,6 +1,7 @@
 package guidTranslator
 
 import (
+	"fmt"
 	"strings"
 
 	"code.cloudfoundry.org/cli/plugin"
@@ -74,6 +75,7 @@ func FindInstanceName(cliConnection plugin.CliConnection, InstanceGuid string, o
 func ServiceNameFromInstance(cliConnection plugin.CliConnection, instanceId string) string {
 	serviceInstance, err := cliConnection.GetService(instanceId)
 	if err != nil {
+		fmt.Println(err)
 		errors.CfCliPluginError("/v2/service_instance/" + instanceId)
 	}
 	serviceName := serviceInstance.ServiceOffering.Name

--- a/service-fabrik-plugin.go
+++ b/service-fabrik-plugin.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"code.cloudfoundry.org/cli/plugin"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"code.cloudfoundry.org/cli/plugin"
 	"github.com/SAP/service-fabrik-cli-plugin/backup"
 	"github.com/SAP/service-fabrik-cli-plugin/errors"
 	"github.com/SAP/service-fabrik-cli-plugin/events"
 	"github.com/SAP/service-fabrik-cli-plugin/helper"
 	"github.com/SAP/service-fabrik-cli-plugin/restore"
 	"github.com/cloudfoundry/cli/cf/trace"
-	"io"
-	"os"
-	"strconv"
-	"strings"
 )
 
 //Dynamically set during build time
@@ -235,7 +236,7 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 		Name:    "ServiceFabrikPlugin",
 		Version: setVersion(Version),
 		Commands: []plugin.Command{
-			{ // required to be a registered command
+			/*{ // required to be a registered command
 				Name:     "start-backup",
 				HelpText: "Start backup of a service instance",
 				UsageDetails: plugin.Usage{
@@ -248,7 +249,7 @@ func (serviceFabrikPlugin *ServiceFabrikPlugin) GetMetadata() plugin.PluginMetad
 				UsageDetails: plugin.Usage{
 					Usage: "cf abort-backup SERVICE_INSTANCE_NAME",
 				},
-			},
+			},*/
 			{
 				Name:     "list-backup",
 				HelpText: "List backup(s) of a service instance",


### PR DESCRIPTION
* Removal of `start-backup` and `abort-backup` commands.
* In the processing of `cf list-backup` an extra validation step is added to verify that the command is supported only for specific services.